### PR TITLE
Use Latest Messages Package (OSK-4)

### DIFF
--- a/src/OSK.Messages.Couriers.Pigeons/Internal/Services/PigeonHold.cs
+++ b/src/OSK.Messages.Couriers.Pigeons/Internal/Services/PigeonHold.cs
@@ -9,7 +9,6 @@ using System;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
-using OSK.Messages.Messaging.Ports;
 
 namespace OSK.Messages.Couriers.Pigeons.Internal.Services;
 

--- a/src/OSK.Messages.Couriers.Pigeons/Models/CourierPigeonDescriptor.cs
+++ b/src/OSK.Messages.Couriers.Pigeons/Models/CourierPigeonDescriptor.cs
@@ -1,6 +1,5 @@
 ﻿using OSK.Messages.Abstractions;
 using OSK.Messages.Couriers.Pigeons.Ports;
-using OSK.Messages.Messaging.Models;
 using System;
 
 namespace OSK.Messages.Couriers.Pigeons.Models;

--- a/src/OSK.Messages.Couriers.Pigeons/OSK.Messages.Couriers.Pigeons.csproj
+++ b/src/OSK.Messages.Couriers.Pigeons/OSK.Messages.Couriers.Pigeons.csproj
@@ -25,7 +25,7 @@
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.6" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.6" />
 		<PackageReference Include="Microsoft.Extensions.Options" Version="10.0.6" />
-		<PackageReference Include="OSK.Messages.Messaging" Version="0.1.0" />
+		<PackageReference Include="OSK.Messages.Abstractions" Version="0.2.0" />
 	</ItemGroup>
 
 </Project>

--- a/src/OSK.Messages.Couriers.Pigeons/ServiceCollectionExtensions.cs
+++ b/src/OSK.Messages.Couriers.Pigeons/ServiceCollectionExtensions.cs
@@ -1,10 +1,10 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using OSK.Messages.Abstractions;
 using OSK.Messages.Couriers.Pigeons.Internal.Services;
 using OSK.Messages.Couriers.Pigeons.Models;
 using OSK.Messages.Couriers.Pigeons.Options;
 using OSK.Messages.Couriers.Pigeons.Ports;
-using OSK.Messages.Messaging;
 using System;
 
 namespace OSK.Messages.Couriers.Pigeons;


### PR DESCRIPTION
Motivation
----
There was an update that made the messages library more flexible by removing the requirement to have a dependency on the core implementation

Modifications
----
* Update to latest messages package
* Remove dependency on core implementation
* Update code to use new messages package

Result
----
The code is now using the latest messages package and is no longer dependent on the core implementation

Fixes #4