### PR TITLE
Downgrade Microsoft.Extensions packages to version 10.0.6 (OSK-8)

### DIFF
--- a/src/OSK.Messages.Couriers.Pigeons/OSK.Messages.Couriers.Pigeons.csproj
+++ b/src/OSK.Messages.Couriers.Pigeons/OSK.Messages.Couriers.Pigeons.csproj
@@ -22,9 +22,9 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="11.0.0-preview.3.26207.106" />
-		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="11.0.0-preview.3.26207.106" />
-		<PackageReference Include="Microsoft.Extensions.Options" Version="11.0.0-preview.3.26207.106" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.6" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.6" />
+		<PackageReference Include="Microsoft.Extensions.Options" Version="10.0.6" />
 		<PackageReference Include="OSK.Messages.Abstractions" Version="0.3.0" />
 	</ItemGroup>
 


### PR DESCRIPTION
Motivation
----
There are packages mistakenly set to the wrong version

Modifications
----
* Downgrade packages mistakenly set

Result
----
The packages are on the latest, released versions

Fixes #8