### PR TITLE
Renaming the extension project to better align with messaging (OSK-12)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A local on-device message courier that integrates into the OSK.Messaging system,
 
 Messages can be sent either in-process or using a background thread if desired
 
-# OSK.Extensions.Couriers.Pigeons.Messaging
+# OSK.Extensions.Messaging.Pigeons
 
 Extends the OSK Messaging system with a built-in extension that combines the configuration setup for both a message center and pigeon courier into a single call. This is mostly for convenience when only requiring setup with a standalone local messaging system
 

--- a/src/OSK.Extensions.Messaging.Pigeons/Internal/Services/MessagingConfigurator.cs
+++ b/src/OSK.Extensions.Messaging.Pigeons/Internal/Services/MessagingConfigurator.cs
@@ -1,9 +1,9 @@
-﻿using OSK.Extensions.Couriers.Pigeons.Messaging.Ports;
-using OSK.Messages.Couriers.Pigeons.Options;
+﻿using OSK.Messages.Couriers.Pigeons.Options;
 using OSK.Messages.Messaging.Ports;
 using System;
+using OSK.Extensions.Messaging.Pigeons.Ports;
 
-namespace OSK.Extensions.Couriers.Pigeons.Messaging.Internal.Services;
+namespace OSK.Extensions.Messaging.Pigeons.Internal.Services;
 
 internal class MessagingConfigurator : IPigeonMessagingConfigurator
 {

--- a/src/OSK.Extensions.Messaging.Pigeons/OSK.Extensions.Messaging.Pigeons.csproj
+++ b/src/OSK.Extensions.Messaging.Pigeons/OSK.Extensions.Messaging.Pigeons.csproj
@@ -14,7 +14,7 @@
 		<PackageReadmeFile>README.md</PackageReadmeFile>
 		<Description>Extends the OSK Courier pigeons to configure and run as a standalone local messaging system using the courier pigeons</Description>
 		<PackageTags>OpenSourceKingdom, OpenSource, messaging, event, bus, delivery, message, courier, dispatch, pigeon, local, device, standalone</PackageTags>
-		<Title>OSK.Extensions.Couriers.Pigeons.Messaging</Title>
+		<Title>OSK.Extensions.Messaging.Pigeons</Title>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/src/OSK.Extensions.Messaging.Pigeons/Ports/IPigeonMessagingConfigurator.cs
+++ b/src/OSK.Extensions.Messaging.Pigeons/Ports/IPigeonMessagingConfigurator.cs
@@ -2,10 +2,12 @@
 using OSK.Messages.Couriers.Pigeons.Options;
 using OSK.Messages.Messaging.Ports;
 using System;
-using OSK.Extensions.Messaging.Pigeons.Ports;
 
 namespace OSK.Extensions.Messaging.Pigeons.Ports;
 
+/// <summary>
+/// A configurator that is able to configure both the pigeon courier and messaging system
+/// </summary>
 [HexagonalIntegration(HexagonalIntegrationType.LibraryProvided)]
 public interface IPigeonMessagingConfigurator
 {

--- a/src/OSK.Extensions.Messaging.Pigeons/Ports/IPigeonMessagingConfigurator.cs
+++ b/src/OSK.Extensions.Messaging.Pigeons/Ports/IPigeonMessagingConfigurator.cs
@@ -2,8 +2,9 @@
 using OSK.Messages.Couriers.Pigeons.Options;
 using OSK.Messages.Messaging.Ports;
 using System;
+using OSK.Extensions.Messaging.Pigeons.Ports;
 
-namespace OSK.Extensions.Couriers.Pigeons.Messaging.Ports;
+namespace OSK.Extensions.Messaging.Pigeons.Ports;
 
 [HexagonalIntegration(HexagonalIntegrationType.LibraryProvided)]
 public interface IPigeonMessagingConfigurator

--- a/src/OSK.Extensions.Messaging.Pigeons/ServiceCollectionExtensions.cs
+++ b/src/OSK.Extensions.Messaging.Pigeons/ServiceCollectionExtensions.cs
@@ -1,11 +1,11 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
-using OSK.Extensions.Couriers.Pigeons.Messaging.Internal.Services;
-using OSK.Extensions.Couriers.Pigeons.Messaging.Ports;
 using OSK.Messages.Couriers.Pigeons;
 using OSK.Messages.Messaging;
 using System;
+using OSK.Extensions.Messaging.Pigeons.Internal.Services;
+using OSK.Extensions.Messaging.Pigeons.Ports;
 
-namespace OSK.Extensions.Couriers.Pigeons.Messaging;
+namespace OSK.Extensions.Messaging.Pigeons;
 
 public static class ServiceCollectionExtensions
 {

--- a/src/OSK.Messages.Couriers.Pigeons.slnx
+++ b/src/OSK.Messages.Couriers.Pigeons.slnx
@@ -1,4 +1,4 @@
 <Solution>
-  <Project Path="OSK.Extensions.Couriers.Pigeons.Messaging/OSK.Extensions.Couriers.Pigeons.Messaging.csproj" Id="068ce96a-6aa8-41f9-8f07-fad54957aba6" />
+  <Project Path="OSK.Extensions.Messaging.Pigeons/OSK.Extensions.Messaging.Pigeons.csproj" Id="068ce96a-6aa8-41f9-8f07-fad54957aba6" />
   <Project Path="OSK.Messages.Couriers.Pigeons/OSK.Messages.Couriers.Pigeons.csproj" />
 </Solution>


### PR DESCRIPTION
Motivation
----
Current extension namespace implies relation to the courier itself rather than the action of messaging with the courier (semantic)

Modifications
----
* Renaming the extension messaging project to align with the priority of (local) messaging rather than the courier itself

Result
----
Renamed project prior to release

Fixes #12